### PR TITLE
microbenchmark/apic-ipi: replace deprecated header

### DIFF
--- a/microbenchmark/apic-ipi/apic_ipi.c
+++ b/microbenchmark/apic-ipi/apic_ipi.c
@@ -4,7 +4,7 @@
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/delay.h>
-#include <asm/ipi.h>
+#include <asm/irq_vectors.h>
 #include <asm/apic.h>
 #include "../common/rdtsc.h"
 


### PR DESCRIPTION
Since linux 5.4 (actually commit 8b542da), asm/ipi.h is no longer available. Use asm/irq_vectors.h instead.
